### PR TITLE
Added support for optional flat-list display of "All Books"

### DIFF
--- a/base.php
+++ b/base.php
@@ -645,7 +645,12 @@ class PageAllBooks extends Page
     public function InitializeContent ()
     {
         $this->title = localize ("allbooks.title");
-        $this->entryArray = Book::getAllBooks ();
+        if (getCurrentOption ("titles_split_first_letter") == 1) {
+            $this->entryArray = Book::getAllBooks();
+        }
+        else {
+            list ($this->entryArray, $this->totalNumber) = Book::getBooks ($this->n);
+        }
         $this->idPage = Book::ALL_BOOKS_ID;
     }
 }

--- a/book.php
+++ b/book.php
@@ -19,6 +19,7 @@ require_once('resources/php-epub-meta/epub.php');
 define ('SQL_BOOKS_LEFT_JOIN', "left outer join comments on comments.book = books.id 
                                 left outer join books_ratings_link on books_ratings_link.book = books.id 
                                 left outer join ratings on books_ratings_link.rating = ratings.id ");
+define ('SQL_BOOKS_ALL', "select {0} from books " . SQL_BOOKS_LEFT_JOIN . " order by books.sort ");
 define ('SQL_BOOKS_BY_FIRST_LETTER', "select {0} from books " . SQL_BOOKS_LEFT_JOIN . "
                                                     where upper (books.sort) like ? order by books.sort");
 define ('SQL_BOOKS_BY_AUTHOR', "select {0} from books_authors_link, books " . SQL_BOOKS_LEFT_JOIN . "
@@ -47,6 +48,7 @@ class Book extends Base {
     const BOOK_COLUMNS = "books.id as id, books.title as title, text as comment, path, timestamp, pubdate, series_index, uuid, has_cover, ratings.rating";
     
     const SQL_BOOKS_LEFT_JOIN = SQL_BOOKS_LEFT_JOIN;
+    const SQL_BOOKS_ALL = SQL_BOOKS_ALL;
     const SQL_BOOKS_BY_FIRST_LETTER = SQL_BOOKS_BY_FIRST_LETTER;
     const SQL_BOOKS_BY_AUTHOR = SQL_BOOKS_BY_AUTHOR;
     const SQL_BOOKS_BY_SERIE = SQL_BOOKS_BY_SERIE;
@@ -530,7 +532,12 @@ where data.book = books.id and data.id = ?');
     public static function getBooksByQuery($query, $n, $database = NULL) {
         return self::getEntryArray (self::SQL_BOOKS_QUERY, $query, $n, $database);
     }
-    
+
+    public static function getBooks($n) {
+        list ($entryArray, $totalNumber) = self::getEntryArray (self::SQL_BOOKS_ALL , array (), $n);
+        return array ($entryArray, $totalNumber);
+    }
+
     public static function getAllBooks() {
         $result = parent::getDb ()->query("select substr (upper (sort), 1, 1) as title, count(*) as count
 from books

--- a/config_default.php
+++ b/config_default.php
@@ -137,6 +137,13 @@
      * 0 : No
      */
     $config['cops_author_split_first_letter'] = "1";  
+
+    /*
+     * split titles by first letter
+     * 1 : Yes
+     * 0 : No
+     */
+    $config['cops_titles_split_first_letter'] = "1";  
     
     /*
      * Enable the Lightboxes (for popups)


### PR DESCRIPTION
Files modified:

config_default.php

base.php

changed class PageAllBooks to test for configuration option "cops_titles_split_first_letter".
Used getCurrentOption to prepare for making Split Letter options configurable in web GUI

book.php

added SQL_BOOKS_ALL query to have a flat-list datasource not grouped by first letter.
added const SQL_BOOKS_ALL to class Book
added public static function "getBooks", called from Base::PageAllBooks to retrieve the flat-list
