### PR TITLE
Create Installation sous Windows WAMP

### DIFF
--- a/Installation sous Windows WAMP
+++ b/Installation sous Windows WAMP
@@ -1,0 +1,10 @@
+Bonjour,
+Je n'arrive pas a parametrer COPS pour utiliser la base Calibre sous Windows.
+J'utilise WAMP
+Est-il possible d'avoir le config_default.php afin de pouvoir parametrer correctement les chemin?
+Exemple la base est sur Z:\Livres
+
+Et s'il y a d'autres choses a savoir?
+
+Merci pour votre réponse.
+Cordialement


### PR DESCRIPTION
Bonjour,
Je n'arrive pas a parametrer COPS pour utiliser la base Calibre sous Windows.
J'utilise WAMP
Est-il possible d'avoir le config_default.php afin de pouvoir parametrer correctement les chemin?
Exemple la base est sur Z:\Livres

Et s'il y a d'autres choses a savoir?

Merci pour votre réponse.
Cordialement
