### PR TITLE
Added support for username based configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test/text.atom
 cops.zip
 cops.sublime-*
 config_local.php
+config_local.*.php

--- a/config.php
+++ b/config.php
@@ -6,9 +6,18 @@
  * @author     Sébastien Lucas <sebastien@slucas.fr>
  */
 
-    require_once 'config_default.php';
-    if (file_exists(dirname(__FILE__). '/config_local.php') && (php_sapi_name() !== 'cli'))
-        require_once 'config_local.php';
+require_once 'config_default.php';
+if (file_exists(dirname(__FILE__) . '/config_local.php') && (php_sapi_name() !== 'cli')) {
+    require_once 'config_local.php';
+}
+
+$remote_user = array_key_exists('PHP_AUTH_USER', $_SERVER) ? $_SERVER['PHP_AUTH_USER'] : '';
+// Clean username, only allow a-z, A-Z, 0-9, -_ chars
+$remote_user = preg_replace( "/[^a-zA-Z0-9_-]/", "", $remote_user);
+$user_config_file = 'config_local.' . $remote_user . '.php';
+if (file_exists(dirname(__FILE__) . '/' . $user_config_file) && (php_sapi_name() !== 'cli')) {
+    require_once $user_config_file;
+}
 
 if(!is_null($config['cops_basic_authentication']) &&
     is_array($config['cops_basic_authentication']))


### PR DESCRIPTION
Added support for username based configs (issue #169). When using .htpasswd files, just create a config_local.<username>.php file with the user specific configuration. Be aware a username can only contain a-z, A-Z, 0-9 and _- characters.

When using the cops basic authentication you need to add a master account into the config_local.php like:

```
$config['cops_basic_authentication'] = array('username'=>'master', 'password' => 'master-password');
```

And add the same line in your config_local.<username>.php file with the username account and the specific configuration options for this user.

Is this ok? and where do you want to have the docs for this feature? I was thinking about a line in the default config to a new wiki page?
