### PR TITLE
Fixed css to show filter correctly

### DIFF
--- a/templates/bootstrap/file.html
+++ b/templates/bootstrap/file.html
@@ -128,12 +128,12 @@
         opacity: 0.5;
     }
 
-    .filter-include {
+    #filter li.filter-include {
         border-left:thick solid blue;
         opacity: 1;
     }
 
-    .filter-exclude {
+    #filter li.filter-exclude {
         border-right:thick solid red;
         opacity: 1;
     }


### PR DESCRIPTION
With the previous version, the two affected css lines were overridden by

```css
#filter li {
    border: 2px solid #DDDDDD;
}
```
with this little change, the filtering tags are highlighted correctly.