### PR TITLE
New icon for cog icon

### DIFF
--- a/templates/default/header.html
+++ b/templates/default/header.html
@@ -1,6 +1,6 @@
 <header>
     <a class="headleft" href="{{=it.homeurl}}" {{=it.c.config.kindleHack}}>
-        <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon48"><i class="icon-book"></i></div>
+        <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon64"><i class="icon-home"></i></div>
     </a>
     {{? it.c.config.server_side_rendering == 0}}
     <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon32 headright"><i class="icon-search icon-2x" id="searchImage"></i></div>

--- a/templates/default/header.html
+++ b/templates/default/header.html
@@ -1,9 +1,9 @@
 <header>
     <a class="headleft" href="{{=it.homeurl}}" {{=it.c.config.kindleHack}}>
-        <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon64"><i class="icon-home"></i></div>
+        <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon48"><i class="icon-book"></i></div>
     </a>
     {{? it.c.config.server_side_rendering == 0}}
-    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon64 headright"><i class="icon-cog" id="searchImage"></i></div>
+    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon32 headright"><i class="icon-search icon-2x" id="searchImage"></i></div>
     {{?}}
     <div class="headcenter">
         <h1>{{=it.title}}</h1>

--- a/templates/default/header.html
+++ b/templates/default/header.html
@@ -3,7 +3,7 @@
         <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon64"><i class="icon-home"></i></div>
     </a>
     {{? it.c.config.server_side_rendering == 0}}
-    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon32 headright"><i class="icon-search icon-2x" id="searchImage"></i></div>
+    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon64 headright"><i class="icon-search" id="searchImage"></i></div>
     {{?}}
     <div class="headcenter">
         <h1>{{=it.title}}</h1>

--- a/templates/default/styles/style-base.css
+++ b/templates/default/styles/style-base.css
@@ -160,13 +160,6 @@ header {
     height: 32px;
 }
 
-.hicon48{
-    font-size: 48px;
-    line-height: 48px;
-    width: 48px;
-    height: 48px;
-}
-
 .headleft {
     float: left;
 }

--- a/templates/default/styles/style-base.css
+++ b/templates/default/styles/style-base.css
@@ -160,6 +160,13 @@ header {
     height: 32px;
 }
 
+.hicon48{
+    font-size: 48px;
+    line-height: 48px;
+    width: 48px;
+    height: 48px;
+}
+
 .headleft {
     float: left;
 }


### PR DESCRIPTION
Changing icons for home and cog (in the header)
Home => Book
Cog => Magnifying glass / search

Also making new search icon smaller to be better looking and also more space to top title

Why? 
- Book icon because this is a "library" and its more fun!
- Magnifying glass its usually considered the search button when the Cog is considered a configurations tool. People always ask where is the search button?

Previous look:
![2016-01-12 16_15_16-000569-cops demo](https://cloud.githubusercontent.com/assets/3055443/12269582/10707b50-b94a-11e5-9b47-1833190fdeb0.png)

New Look
![2016-01-12 15_36_13-000568-estante digital](https://cloud.githubusercontent.com/assets/3055443/12269601/291b28a8-b94a-11e5-8737-5455582eedcb.png)
