### PR TITLE
Including HTTP_USER_AGENT for ebookdroid android app

### DIFF
--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@
     require_once ("resources/doT-php/doT.php");
 
     // If we detect that an OPDS reader try to connect try to redirect to feed.php
-    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader|Reader|Dalvik|org.ebookdroid)/", $_SERVER['HTTP_USER_AGENT'])) {
+    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader|org.ebookdroid)/", $_SERVER['HTTP_USER_AGENT'])) {
         header("location: feed.php");
         exit ();
     }

--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@
     require_once ("resources/doT-php/doT.php");
 
     // If we detect that an OPDS reader try to connect try to redirect to feed.php
-    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader|org.ebookdroid)/", $_SERVER['HTTP_USER_AGENT'])) {
+    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader|org\.ebookdroid)/", $_SERVER['HTTP_USER_AGENT'])) {
         header("location: feed.php");
         exit ();
     }

--- a/index.php
+++ b/index.php
@@ -20,7 +20,7 @@
     require_once ("resources/doT-php/doT.php");
 
     // If we detect that an OPDS reader try to connect try to redirect to feed.php
-    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader)/", $_SERVER['HTTP_USER_AGENT'])) {
+    if (preg_match("/(MantanoReader|FBReader|Stanza|Marvin|Aldiko|Moon+ Reader|Chunky|AlReader|Reader|Dalvik|org.ebookdroid)/", $_SERVER['HTTP_USER_AGENT'])) {
         header("location: feed.php");
         exit ();
     }


### PR DESCRIPTION
Including HTTP_USER_AGENT for android apps
Ebookdroid https://play.google.com/store/apps/details?id=org.ebookdroid
org.ebookdroid 2.3.5

this is related to issue https://github.com/seblucas/cops/issues/236

=Update: below listed apps was not included following discussion below.
They will require changes on user agents from the apps developer!

FullReader+ https://play.google.com/store/apps/details?id=com.fullreader
Reader/2.3.1(java)

PocketBook reader https://play.google.com/store/apps/details?id=com.obreey.reader
Dalvik/2.1.0