### PR TITLE
Use a cache for resized thumbnails

### DIFF
--- a/config_default.php
+++ b/config_default.php
@@ -229,6 +229,15 @@
     $config['cops_thumbnail_handling'] = "";
 
     /*
+     * Directory to keep resized thumbnails: allow to resize thumbnails only on first access, then use this cache.
+     * $config['cops_thumbnail_handling'] must be ""
+     * "" : don't cache thumbnail
+     * "/tmp/cache/" (example) : will generate thumbnails in /tmp/cache/
+     * BEWARE : it has to end with a /
+     */
+    $config['cops_thumbnail_cache_directory'] = "";
+
+    /*
      * Contains a list of user agent for browsers not compatible with client side rendering
      * For now : Kindle, Sony PRS-T1, Sony PRS-T2, All Cybook devices (maybe a little extreme).
      * This item is used as regular expression so "." will force server side rendering for all devices

--- a/fetch.php
+++ b/fetch.php
@@ -57,9 +57,44 @@
     {
         case "jpg":
             header("Content-Type: image/jpeg");
-            if ($book->getThumbnail (getURLParam ("width"), getURLParam ("height"))) {
-                // The cover had to be resized
+            //by default, we don't cache
+            $thumbnailCacheFullpath = null;
+            if ( isset($config['cops_thumbnail_cache_directory']) && $config['cops_thumbnail_cache_directory'] !== '' ) {
+                $thumbnailCacheFullpath = $config['cops_thumbnail_cache_directory'];
+                //if multiple databases, add a subfolder with the database ID
+                $thumbnailCacheFullpath .= !is_null (GetUrlParam (DB)) ? 'db-' . GetUrlParam (DB) . DIRECTORY_SEPARATOR : '';
+                //when there are lots of thumbnails, it's better to save files in subfolders, so if the book's uuid is
+                //"01234567-89ab-cdef-0123-456789abcdef", we will save the thumbnail in .../0/12/34567-89ab-cdef-0123-456789abcdef-...
+                $thumbnailCacheFullpath .= substr($book->uuid, 0, 1) . DIRECTORY_SEPARATOR . substr($book->uuid, 1, 2) . DIRECTORY_SEPARATOR;
+                //check if cache folder exists or create it
+                if ( file_exists($thumbnailCacheFullpath) || mkdir($thumbnailCacheFullpath, 0700, true) ) {
+                    //we name the thumbnail from the book's uuid and it's dimensions (width and/or height)
+                    $thumbnailCacheName = substr($book->uuid, 3) . '-' . getURLParam ("width") . 'x' . getURLParam ("height") . '.jpg';
+                    $thumbnailCacheFullpath = $thumbnailCacheFullpath . $thumbnailCacheName;
+                }
+                else {
+                    //error creating the folder, so we don't cache
+                    $thumbnailCacheFullpath = null;
+                }
+            }
+
+            if ( $thumbnailCacheFullpath !== null && file_exists($thumbnailCacheFullpath) ) {
+                //return the already cached thumbnail
+                readfile( $thumbnailCacheFullpath );
                 return;
+            }
+
+            if ($book->getThumbnail (getURLParam ("width"), getURLParam ("height"), $thumbnailCacheFullpath)) {
+                //if we don't cache the thumbnail, imagejpeg() in $book->getThumbnail() already return the image data
+                if ( $thumbnailCacheFullpath === null ) {
+                    // The cover had to be resized
+                    return;
+                }
+                else {
+                    //return the just cached thumbnail
+                    readfile( $thumbnailCacheFullpath );
+                    return;
+                }
             }
             break;
         default:


### PR DESCRIPTION
Add the new config parameter $config['cops_thumbnail_cache_directory'] to store resized book's covers.

Directory structure is optimized for best performance