### PR TITLE
Remove unsupported characters from epub filenames

### DIFF
--- a/data.php
+++ b/data.php
@@ -96,7 +96,8 @@ class Data extends Base {
     }
 
     public function getUpdatedFilename () {
-        return $this->book->getAuthorsSort () . " - " . $this->book->title;
+        $str = $this->book->getAuthorsSort () . " - " . $this->book->title;
+	return preg_replace( '/[^[:alnum:]\._\- ,]/', '-', $str );
     }
 
     public function getUpdatedFilenameEpub () {


### PR DESCRIPTION
This originally targetted kepubs only but I moved the filtering up a
level to the filename generation for all epubs in case other devices
have the same problem.

This removes everything except:

- Alphanumeric
- .
- _
- -
- ,
- space

from filenames generated by getUpdatedFilename().

Fixes #263.