### PR TITLE
Fixed duplicate authorsName in template

### DIFF
--- a/templates/default/main.html
+++ b/templates/default/main.html
@@ -39,7 +39,6 @@
                 <h4>{{=it.c.i18n.authorsTitle}} : </h4><span class="sa">{{=htmlspecialchars (entry.book.authorsName)}}</span><br />
                 {{? entry.book.tagsName != ""}}<h4>{{=it.c.i18n.tagsTitle}} : </h4><span class="se">{{=htmlspecialchars (entry.book.tagsName)}}</span><br />{{?}}
                 {{? entry.book.seriesName != ""}}<h4>{{=it.c.i18n.seriesTitle}} : </h4><span class="ss">{{=htmlspecialchars (entry.book.seriesName)}} ({{=entry.book.seriesIndex}})</span><br />{{?}}
-                <h4>{{=it.c.i18n.authorsTitle}} : </h4><span class="sa">{{=htmlspecialchars (entry.book.authorsName)}}</span><br />
                 {{~entry.book.customcolumns_list :column:column_index}}
                 <h4>{{=column.customColumnType.columnTitle}} : </h4><span class="se">{{=column.htmlvalue}}</span><br />
                 {{~}}


### PR DESCRIPTION
Looks like I accidently duplicated the authorsName entry in the default template, which leads to it being displayed two times:

![example](https://i.imgur.com/LIBy7nB.png)

It was me that introduced that bug in fe386b4, sorry :(

*(Unfortunately I had, until today, a dev build on my server and didn't notice the bug until I updated all the stuff to the current version)*

&nbsp;

Regards
  ~ Mike