### PR TITLE
Fixed CustomColumnTypeText showing id instead of text when created by getCustomByBook()

### DIFF
--- a/customcolumn.php
+++ b/customcolumn.php
@@ -674,7 +674,7 @@ class CustomColumnTypeEnumeration extends CustomColumnType
 
     public function getCustomByBook($book)
     {
-        $queryFormat = "SELECT {0}.id AS id, {1}.{2} AS name FROM {0}, {1} WHERE {0}.id = {1}.{2} AND {1}.book = {3}";
+        $queryFormat = "SELECT {0}.id AS id, {0}.{2} AS name FROM {0}, {1} WHERE {0}.id = {1}.{2} AND {1}.book = {3}";
         $query = str_format($queryFormat, $this->getTableName(), $this->getTableLinkName(), $this->getTableLinkColumn(), $book->id);
 
         $result = $this->getDb()->query($query);

--- a/customcolumn.php
+++ b/customcolumn.php
@@ -484,7 +484,7 @@ class CustomColumnTypeText extends CustomColumnType
 
     public function getCustomByBook($book)
     {
-        $queryFormat = "SELECT {0}.id AS id, {1}.{2} AS name FROM {0}, {1} WHERE {0}.id = {1}.{2} AND {1}.book = {3} ORDER BY {0}.value";
+        $queryFormat = "SELECT {0}.id AS id, {0}.{2} AS name FROM {0}, {1} WHERE {0}.id = {1}.{2} AND {1}.book = {3} ORDER BY {0}.value";
         $query = str_format($queryFormat, $this->getTableName(), $this->getTableLinkName(), $this->getTableLinkColumn(), $book->id);
 
         $result = $this->getDb()->query($query);

--- a/test/customColumnsTest.php
+++ b/test/customColumnsTest.php
@@ -955,12 +955,12 @@ class CustomColumnTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals("custom_01", $custom[0]->customColumnType->columnTitle);
         $this->assertEquals($custom[0]->customColumnType->getTitle(), $custom[0]->customColumnType->columnTitle);
-        $this->assertEquals("2", $custom[0]->htmlvalue);
+        $this->assertEquals("text_2", $custom[0]->htmlvalue);
         $this->assertEquals($custom[0]->getHTMLEncodedValue(), $custom[0]->htmlvalue);
 
         $this->assertEquals("custom_02", $custom[1]->customColumnType->columnTitle);
         $this->assertEquals($custom[1]->customColumnType->getTitle(), $custom[1]->customColumnType->columnTitle);
-        $this->assertEquals("1", $custom[1]->htmlvalue);
+        $this->assertEquals("a", $custom[1]->htmlvalue);
         $this->assertEquals($custom[1]->getHTMLEncodedValue(), $custom[1]->htmlvalue);
 
         $this->assertEquals("custom_03", $custom[2]->customColumnType->columnTitle);

--- a/test/customColumnsTest.php
+++ b/test/customColumnsTest.php
@@ -975,7 +975,7 @@ class CustomColumnTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals("custom_05", $custom[4]->customColumnType->columnTitle);
         $this->assertEquals($custom[4]->customColumnType->getTitle(), $custom[4]->customColumnType->columnTitle);
-        $this->assertEquals("6", $custom[4]->htmlvalue);
+        $this->assertEquals("val05", $custom[4]->htmlvalue);
         $this->assertEquals($custom[4]->getHTMLEncodedValue(), $custom[4]->htmlvalue);
 
         $this->assertEquals("custom_06", $custom[5]->customColumnType->columnTitle);


### PR DESCRIPTION
Custom text columns currently display only their internal ID in bookdetail.html and main.html.

The problem was the SQL query in `public function getCustomByBook($book)` queries the `column_x_link.value` instead of `column_x.value`.
(and annoyingly the value-table and the link-table have the same column name `value`. So the query didn't even fail but just returned the wrong value -.-)

See also: http://www.mobileread.com/forums/showpost.php?p=3352831&postcount=1291

Greets
  ~ Mike