### PR TITLE
Removes "header()" to send as HTML

### DIFF
--- a/checkconfig.php
+++ b/checkconfig.php
@@ -5,14 +5,12 @@
  * COPS (Calibre OPDS PHP Server) Configuration check
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Sébastien Lucas <sebastien@slucas.fr>
+ * @author     SÃ©bastien Lucas <sebastien@slucas.fr>
  *
  */
 
     require_once ("config.php");
     require_once ("base.php");
-
-    header ("Content-Type:text/html; charset=UTF-8");
 
     $err = getURLParam ("err", -1);
     $full = getURLParam ("full");


### PR DESCRIPTION
This was causing a PHP error as the output body had already commenced at Line 1