### PR TITLE
Fix Github URL to actual Github Cops project

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,7 +3,7 @@
 <h2>Authors</h2>
 <p>COPS is developed and maintained by Sébastien Lucas.</p>
 
-<p>See full history on <a href="https://github.com/seblucas">Github</a> to check all authors.</p>
+<p>See full history on <a href="https://github.com/seblucas/cops">Github</a> to check all authors.</p>
 
 <p>COPS use some external libraries, check README for the details.</p>
 <h2>Copyright</h2>


### PR DESCRIPTION
Small fix: 
The actual link takes you to the autor page on github, not to the Cops project