### PR TITLE
Changing cog icon to a magnifying glass

### DIFF
--- a/templates/default/header.html
+++ b/templates/default/header.html
@@ -3,7 +3,7 @@
         <div title="{{=it.c.i18n.homeAlt}}" class="hicon hicon64"><i class="icon-home"></i></div>
     </a>
     {{? it.c.config.server_side_rendering == 0}}
-    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon64 headright"><i class="icon-cog" id="searchImage"></i></div>
+    <div title="{{=it.c.i18n.cogAlt}}" class="hicon hicon64 headright"><i class="icon-search" id="searchImage"></i></div>
     {{?}}
     <div class="headcenter">
         <h1>{{=it.title}}</h1>


### PR DESCRIPTION
Changing cog icon (in the header) to a magnifying glass / search
![newcogicon](https://cloud.githubusercontent.com/assets/3055443/21197786/a1ce6f3c-c234-11e6-8257-9dd7bcc741db.png)

Why? Magnifying glass its usually considered the search button when the Cog is considered a "configuration tool".
With actual COPS theme people always ask me "where is the search button"?
For me this is now solved on my installs!



