### PR TITLE
Improves opds validation

### DIFF
--- a/lib/OPDS_renderer.php
+++ b/lib/OPDS_renderer.php
@@ -197,7 +197,7 @@ class OPDSRenderer
         self::getXmlStream ()->startElement ("content");
             self::getXmlStream ()->writeAttribute ("type", $entry->contentType);
             self::getXmlStream ()->text ($entry->content);
-         self::getXmlStream ()->endElement ();
+        self::getXmlStream ()->endElement ();
         foreach ($entry->linkArray as $link) {
             self::renderLink ($link);
         }

--- a/lib/OPDS_renderer.php
+++ b/lib/OPDS_renderer.php
@@ -196,12 +196,8 @@ class OPDSRenderer
         self::getXmlStream ()->endElement ();
         self::getXmlStream ()->startElement ("content");
             self::getXmlStream ()->writeAttribute ("type", $entry->contentType);
-            if ($entry->contentType == "text") {
-                self::getXmlStream ()->text ($entry->content);
-            } else {
-                self::getXmlStream ()->writeRaw ($entry->content);
-            }
-        self::getXmlStream ()->endElement ();
+            self::getXmlStream ()->text ($entry->content);
+         self::getXmlStream ()->endElement ();
         foreach ($entry->linkArray as $link) {
             self::renderLink ($link);
         }


### PR DESCRIPTION
HTML should not be written into the XML stream as they are both tag based languages.  Depending on the complexity of the rich text in Calibre that populates the content field, this can stop validation and break some readers.  Notably PocketReader on Android which will not process an invalid OPDS.

```
4.1.3.3.  Processing Model
   2.  If the value of "type" is "html", the content of atom:content
       MUST NOT contain child elements and SHOULD be suitable for
       handling as HTML [HTML].  The HTML markup MUST be escaped; for
       example, "<br>" as "&lt;br>".  The HTML markup SHOULD be such
       that it could validly appear directly within an HTML <DIV>
       element.  Atom Processors that display the content MAY use the
       markup to aid in displaying it.
```