### PR TITLE
fix: use absolute path in place of partial one and calibre internal directory

### DIFF
--- a/fetch.php
+++ b/fetch.php
@@ -3,7 +3,7 @@
  * COPS (Calibre OPDS PHP Server)
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Sébastien Lucas <sebastien@slucas.fr>
+ * @author     SÃ©bastien Lucas <sebastien@slucas.fr>
  */
 
     require_once dirname(__FILE__) . '/config.php';
@@ -98,7 +98,7 @@
             header('Content-Type: ' . $data->getMimeType());
             break;
     }
-    $file = $book->getFilePath($type, $idData, true);
+    $file = $book->getFilePath($type, $idData);
     if (!$viewOnly && $type == 'epub' && $config['cops_update_epub-metadata']) {
         $book->getUpdatedEpub($idData);
         return;
@@ -111,16 +111,10 @@
         header('Content-Disposition: attachment; filename="' . basename($file) . '"');
     }
 
-    $dir = $config['calibre_internal_directory'];
-    if (empty($config['calibre_internal_directory'])) {
-        $dir = Base::getDbDirectory();
-    }
-
     if (empty($config['cops_x_accel_redirect'])) {
-        $filename = $dir . $file;
-        $fp = fopen($filename, 'rb');
-        header('Content-Length: ' . filesize($filename));
+        $fp = fopen($file, 'rb');
+        header('Content-Length: ' . filesize($file));
         fpassthru($fp);
     } else {
-        header($config['cops_x_accel_redirect'] . ': ' . $dir . $file);
+        header($config['cops_x_accel_redirect'] . ': ' . $file);
     }


### PR DESCRIPTION
Using the _calibre internal directory_ concatenated to the _relative path_ is not enough when there is more than a library.

Before:

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/1157864/126908103-1c918783-6fce-439f-ab9e-73a916d8854b.png">

After:

<img width="1331" alt="image" src="https://user-images.githubusercontent.com/1157864/126908234-4324cdea-49b5-4383-a588-3558f41527af.png">
