### PR TITLE
Update fetch.php to lower memory consumption

### DIFF
--- a/fetch.php
+++ b/fetch.php
@@ -3,7 +3,7 @@
  * COPS (Calibre OPDS PHP Server)
  *
  * @license    GPL 2 (http://www.gnu.org/licenses/gpl.html)
- * @author     Sébastien Lucas <sebastien@slucas.fr>
+ * @author     SÃ©bastien Lucas <sebastien@slucas.fr>
  */
 
     require_once dirname(__FILE__) . '/config.php';
@@ -18,6 +18,8 @@
             return;
         }
     }
+    // clean output buffers before sending the ebook data do avoid high memory usage on big ebooks (ie. comic books)
+    ob_end_clean();
 
     $expires = 60*60*24*14;
     header('Pragma: public');
@@ -118,9 +120,9 @@
 
     if (empty($config['cops_x_accel_redirect'])) {
         $filename = $dir . $file;
-        $fp = fopen($filename, 'rb');
         header('Content-Length: ' . filesize($filename));
-        fpassthru($fp);
+        readfile($filename);
     } else {
         header($config['cops_x_accel_redirect'] . ': ' . $dir . $file);
     }
+exit();


### PR DESCRIPTION
On big eBooks like comic books you can hit the PHP memory limit. With this changes there is no need to raise the memory limit in php.ini. Also readfile is recommended in the php documentation instead of fpassthru for most cases so I changed it. Also if you download binary data make sure that there is no output after that therefore an explicit exit() at the end.